### PR TITLE
Fix script init.sh for error: component 'rustfmt' for target 'x86_64-…

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,12 +1,17 @@
+
 #!/usr/bin/env bash
 
 set -e
 
-echo "*** Initializing WASM build environment ***"
+echo "*** Uninstall and reinstall toolchains ***"
+rustup toolchain uninstall stable-x86_64-unknown-linux-gnu
+rustup toolchain uninstall nightly-x86_64-unknown-linux-gnu
+rustup toolchain install nightly
 
+echo "*** Initializing WASM build environment ***"
 if [ -z $CI_PROJECT_NAME ] ; then
+    echo $CI_PROJECT_NAME
     rustup update nightly
     rustup update stable
 fi
-
 rustup target add wasm32-unknown-unknown --toolchain nightly


### PR DESCRIPTION

When I run command
sudo docker run -it --rm   --name substrate-ssvm   -p 9944:9944   -v $(pwd):/root/node   -w /root/node/substrate-ssvm-node   secondstate/substrate-ssvm:latest   /bin/bash -c "make init && make build && cargo run --release --bin ssvm-node -- --dev --ws-external"
It have an error:
error: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is unavailable for download for channel nightly
Sometimes not all components are available in any given nightly. If you don't need the component, you can remove it with:

    rustup component remove --toolchain nightly --target x86_64-unknown-linux-gnu rustfmt
make: *** [Makefile:3: init] Error 1

Reason: I think the lastest of docker image of secondstate/substrate-ssvm have problem with rust

Solution: uninstall chain and reinstall tool chain.